### PR TITLE
Make it work with Refined GitHub extension

### DIFF
--- a/review.js
+++ b/review.js
@@ -21,6 +21,7 @@
   const REF_RE = /Refs?: (.*)/
   const APPROVAL_RE = /(.*) approved these changes/
   const REJECTED_RE = /(.*) requested changes/
+  const LOGIN_RE = / .*/
 
   class Metadata {
     constructor() {
@@ -30,6 +31,7 @@
     }
 
     addApproval(login) {
+      login = login.replace(LOGIN_RE, '')
       if (!this.reviewers.has(login)) {
         this.approvals += 1
         this.reviewers.set(login, STATUS.APPROVED)
@@ -43,6 +45,7 @@
     }
 
     addRejection(login) {
+      login = login.replace(LOGIN_RE, '')
       if (!this.reviewers.has(login)) {
         this.rejections += 1
         this.reviewers.set(login, STATUS.REJECTED)


### PR DESCRIPTION
I'm a user of [Refined GitHub](https://github.com/sindresorhus/refined-github) and a recent change add the name of the individuals next to their GitHub login, which broke this extension:
![screenshot from 2017-08-04 08-54-46](https://user-images.githubusercontent.com/2352663/28957553-97c52cae-78f2-11e7-9093-3c77825d3c74.png)
